### PR TITLE
fix(frontend): button line-height ss-105

### DIFF
--- a/apps/frontend/src/libs/components/button/styles.module.css
+++ b/apps/frontend/src/libs/components/button/styles.module.css
@@ -5,6 +5,7 @@
 	padding: 12px 16px;
 	font-family: Inter, sans-serif;
 	font-size: var(--font-size-small);
+	line-height: 1.5;
 	color: var(--color-text-inverse-strong);
 	text-align: center;
 	text-decoration: none;


### PR DESCRIPTION
Assigned line-height for button to 24/16 = 1.5, so component would match figma design
<img width="368" height="83" alt="image" src="https://github.com/user-attachments/assets/f59cf0f8-2c7d-4333-92e4-1bf379c12791" />
