### PR TITLE
fix(frontend): popular routes typo ss-165

### DIFF
--- a/apps/frontend/src/pages/landing/libs/components/popular-section/popular-section.tsx
+++ b/apps/frontend/src/pages/landing/libs/components/popular-section/popular-section.tsx
@@ -5,7 +5,7 @@ import styles from "./styles.module.css";
 const PopularSection = (): React.JSX.Element => {
 	return (
 		<section className={styles["popular-section"]}>
-			<p className={styles["title"]}>Popular Routes</p>
+			<p className={styles["title"]}>Popular routes</p>
 			<ul className={styles["cards"]}>
 				<RouteCard imageUrl={null} name="Kralovska obora" />
 				<RouteCard imageUrl={null} name="Kralovska obora" />


### PR DESCRIPTION
Fixed popular routes label typo on the landing page