### PR TITLE
fix(frontend): fix inline paddings in header ss-168

### DIFF
--- a/apps/frontend/src/libs/components/header/header.tsx
+++ b/apps/frontend/src/libs/components/header/header.tsx
@@ -17,7 +17,11 @@ const Header = ({ user }: Properties): JSX.Element => {
 	return (
 		<header className={styles["header"]}>
 			<Link to={AppRoute.ROOT}>
-				<img alt="SmartScapes Logo" height={24} src={appLogo} width={136} />
+				<img
+					alt="SmartScapes Logo"
+					className={styles["header-logo"]}
+					src={appLogo}
+				/>
 			</Link>
 			{hasUser ? (
 				<div className={styles["user-info"]}>

--- a/apps/frontend/src/libs/components/header/styles.module.css
+++ b/apps/frontend/src/libs/components/header/styles.module.css
@@ -3,8 +3,15 @@
 	align-items: center;
 	justify-content: space-between;
 	width: 100%;
-	padding: 12px 32px;
+	padding: 12px 120px;
 	border-bottom: 1px solid var(--color-stroke-weak);
+}
+
+.header-logo {
+	display: block;
+	width: 136px;
+	height: 24px;
+	margin: 0 auto;
 }
 
 .user-info {
@@ -17,4 +24,16 @@
 .buttons {
 	display: flex;
 	gap: 8px;
+}
+
+@media (width <= 991px) {
+	.header {
+		padding-inline: 32px;
+	}
+}
+
+@media (width <= 768px) {
+	.header {
+		padding-inline: 16px;
+	}
 }


### PR DESCRIPTION
This pull request updates the `Header` component to improve its layout and responsiveness. The changes include modifying the logo styling, adjusting padding for better spacing, and adding media queries for responsive design.

* Updated the `Header` component to apply a new CSS class, `header-logo`, to the logo image for better control over its styling. 
* Increased the default horizontal padding of the header from `32px` to `120px` , add responsivnes on 991px - inline padding 32px, 768px - 16px. 

Closes #168 