### PR TITLE
fix(frontend): hide middleware errors in production ss-241

### DIFF
--- a/apps/frontend/src/libs/modules/store/store.module.ts
+++ b/apps/frontend/src/libs/modules/store/store.module.ts
@@ -37,11 +37,19 @@ class Store {
 		this.instance = configureStore({
 			devTools: config.ENV.APP.ENVIRONMENT !== AppEnvironment.PRODUCTION,
 			middleware: (getDefaultMiddleware) => {
-				return getDefaultMiddleware({
+				const middlewares = getDefaultMiddleware({
 					thunk: {
 						extraArgument: this.extraArguments,
 					},
-				}).prepend(handleErrorMiddleware(this.extraArguments));
+				});
+
+				if (config.ENV.APP.ENVIRONMENT !== AppEnvironment.DEVELOPMENT) {
+					return middlewares.prepend(
+						handleErrorMiddleware(this.extraArguments),
+					);
+				}
+
+				return middlewares;
 			},
 			reducer: {
 				auth: authReducer,


### PR DESCRIPTION
issue:
- getAuthUser action invokes justified rejection, which lead to handleError middleware catching it and displaying with toastNotifier

solution:
- if ENV is not production, handleErrorMiddleware is not included in frontend Store config