### PR TITLE
feat(frontend): add styles to select

### DIFF
--- a/apps/frontend/src/libs/components/select/libs/constants/select-styles-config.constant.ts
+++ b/apps/frontend/src/libs/components/select/libs/constants/select-styles-config.constant.ts
@@ -3,6 +3,7 @@ import { combineClassNames } from "~/libs/helpers/helpers.js";
 import styles from "../../styles.module.css";
 
 const selectStylesConfig = {
+	clearIndicator: (): string => styles["clear-indicator"] as string,
 	control: (): string => styles["control"] as string,
 	menu: (): string => styles["menu"] as string,
 	multiValue: (): string => styles["multi-value"] as string,

--- a/apps/frontend/src/libs/components/select/styles.module.css
+++ b/apps/frontend/src/libs/components/select/styles.module.css
@@ -81,6 +81,16 @@
 	background-color: var(--color-text-error);
 }
 
+.clear-indicator {
+	color: var(--color-text-strong);
+	cursor: pointer;
+}
+
+.clear-indicator:hover {
+	color: var(--color-base);
+	background-color: var(--color-text-error);
+}
+
 @media (width <=768px) {
 	.control {
 		padding: 8px 10px;

--- a/apps/frontend/src/pages/dashboard/styles.module.css
+++ b/apps/frontend/src/pages/dashboard/styles.module.css
@@ -12,10 +12,13 @@
 
 .carousel-container {
 	width: 50%;
-	margin-bottom: 10rem;
+	margin-bottom: 2rem;
 }
 
 .select-container {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
 	width: 50%;
-	margin-bottom: 5rem;
+	margin-bottom: 10rem;
 }


### PR DESCRIPTION
Added styles to select clear indicator
hover:
<img width="122" height="98" alt="image" src="https://github.com/user-attachments/assets/232aedb4-99cc-4398-b123-d7a48dff0c10" />
Increased gap between selects and bottom of page
<img width="1042" height="425" alt="image" src="https://github.com/user-attachments/assets/113ceadd-343e-4fd1-936d-2007f3a6f5f3" />

Closes #255 