### PR TITLE
fix(backend): update poi location schema in swagger documentation ss-258

### DIFF
--- a/apps/backend/src/modules/points-of-interest/points-of-interest.controller.ts
+++ b/apps/backend/src/modules/points-of-interest/points-of-interest.controller.ts
@@ -32,8 +32,8 @@ import {
  *         coordinates:
  *           type: array
  *           items:
- *             type: number
- *           example: [30.5234, 50.4501]
+ *             type: string
+ *           example: ["30.5234", "50.4501"]
  *         type:
  *           type: string
  *           example: "Point"


### PR DESCRIPTION
Resolves #258 
Updated the coordinates type and example in the PointsOfInterestLocation schema to match the longitude and latitude validation schema.