### PR TITLE
fix(frontend/backend): handle jwt/auth errors appearance ss-248

### DIFF
--- a/apps/backend/src/libs/modules/plugins/auth/auth.plugin.ts
+++ b/apps/backend/src/libs/modules/plugins/auth/auth.plugin.ts
@@ -37,14 +37,21 @@ const auth = (app: FastifyInstance, { whiteRoutes }: PluginOptions): void => {
 		}
 
 		const [, token] = headers.authorization.split(" ");
-		const { userId } = await tokenService.verify<TokenPayload>(token as string);
-		const user = await userService.findById(userId);
 
-		if (!user) {
+		try {
+			const { userId } = await tokenService.verify<TokenPayload>(
+				token as string,
+			);
+			const user = await userService.findById(userId);
+
+			if (!user) {
+				throw new AuthError();
+			}
+
+			request.user = user;
+		} catch {
 			throw new AuthError();
 		}
-
-		request.user = user;
 	};
 
 	app.decorateRequest("user", null);

--- a/apps/frontend/src/libs/modules/api/base-http-api.ts
+++ b/apps/frontend/src/libs/modules/api/base-http-api.ts
@@ -1,8 +1,9 @@
 import { APIErrorType } from "~/libs/enums/enums.js";
 import { configureString } from "~/libs/helpers/helpers.js";
 import {
+	AuthError,
 	type HTTP,
-	type HTTPCode,
+	HTTPCode,
 	HTTPError,
 	HTTPHeader,
 	type HTTPResponse,
@@ -128,13 +129,18 @@ class BaseHTTPApi implements HTTPApi {
 		}
 
 		const details = "details" in errorPayload ? errorPayload.details : [];
-
-		throw new HTTPError({
+		const errorData = {
 			details,
 			message: errorPayload.message,
 			status: response.status as ValueOf<typeof HTTPCode>,
 			type: errorPayload.type,
-		});
+		};
+		const error =
+			response.status === HTTPCode.UNAUTHORIZED
+				? new AuthError(errorData)
+				: new HTTPError(errorData);
+
+		throw error;
 	}
 }
 

--- a/apps/frontend/src/libs/modules/http/http.ts
+++ b/apps/frontend/src/libs/modules/http/http.ts
@@ -4,7 +4,11 @@ const http = new BaseHTTP();
 
 export { http };
 export { HTTPCode, HTTPHeader } from "./libs/enums/enums.js";
-export { HTTPError } from "./libs/exceptions/exceptions.js";
+export {
+	AUTH_ERROR_DEFAULT_NAME,
+	AuthError,
+	HTTPError,
+} from "./libs/exceptions/exceptions.js";
 export {
 	type HTTP,
 	type HTTPOptions,

--- a/apps/frontend/src/libs/modules/http/libs/exceptions/auth.exception.ts
+++ b/apps/frontend/src/libs/modules/http/libs/exceptions/auth.exception.ts
@@ -1,0 +1,37 @@
+import { type APIErrorType } from "~/libs/enums/enums.js";
+import { type HTTPCode } from "~/libs/modules/http/http.js";
+import {
+	type APIValidationErrorDetail,
+	type ValueOf,
+} from "~/libs/types/types.js";
+
+import { HTTPError } from "./http-error.exception.js";
+
+type Constructor = {
+	cause?: unknown;
+	details: APIValidationErrorDetail[];
+	message: string;
+	name?: string;
+	status: ValueOf<typeof HTTPCode>;
+	type: ValueOf<typeof APIErrorType>;
+};
+
+const AUTH_ERROR_DEFAULT_NAME = "Unauthorized";
+
+class AuthError extends HTTPError {
+	public name: string;
+
+	public constructor({
+		cause,
+		details,
+		message,
+		name = AUTH_ERROR_DEFAULT_NAME,
+		status,
+		type,
+	}: Constructor) {
+		super({ cause, details, message, status, type });
+		this.name = name;
+	}
+}
+
+export { AUTH_ERROR_DEFAULT_NAME, AuthError };

--- a/apps/frontend/src/libs/modules/http/libs/exceptions/exceptions.ts
+++ b/apps/frontend/src/libs/modules/http/libs/exceptions/exceptions.ts
@@ -1,1 +1,2 @@
+export { AUTH_ERROR_DEFAULT_NAME, AuthError } from "./auth.exception.js";
 export { HTTPError } from "./http-error.exception.js";

--- a/apps/frontend/src/libs/modules/store/middlewares/handle-error.middleware.ts
+++ b/apps/frontend/src/libs/modules/store/middlewares/handle-error.middleware.ts
@@ -1,12 +1,17 @@
 import { isRejected, type Middleware } from "@reduxjs/toolkit";
 
 import { CommonExceptionMessage } from "~/libs/enums/enums.js";
+import { AUTH_ERROR_DEFAULT_NAME } from "~/libs/modules/http/http.js";
 import { type ExtraArguments } from "~/libs/modules/store/libs/types/types.js";
 
 const handleError = ({ toastNotifier }: ExtraArguments): Middleware => {
 	return () => {
 		return (next) => (action) => {
 			if (isRejected(action)) {
+				if (action.error.name === AUTH_ERROR_DEFAULT_NAME) {
+					return;
+				}
+
 				toastNotifier.showError(
 					action.error.message ??
 						CommonExceptionMessage.COMMON_EXCEPTION_MESSAGE,


### PR DESCRIPTION
Updates:
  -  Added try catch statement in auth plugin for jwt validation
  - Excluded toast notifications for auth errors on the client