### PR TITLE
fix(backend): update route validation schema handling ss-280

### DIFF
--- a/apps/backend/src/libs/modules/server-application/base-server-application.ts
+++ b/apps/backend/src/libs/modules/server-application/base-server-application.ts
@@ -94,8 +94,8 @@ class BaseServerApplication implements ServerApplication {
 
 		if (validation) {
 			routeOptions.schema = {
-				body: validation.body,
-				querystring: validation.query,
+				...(validation.body ? { body: validation.body } : {}),
+				...(validation.query ? { querystring: validation.query } : {}),
 			};
 		}
 


### PR DESCRIPTION
Resolves #280 
Changes:
- `routeOptions.schema` will include only the properties for which a validation schema was provided. For example, if you specify only a query schema in the `addRoute` options, the validation object will contain only the `query` property.