### PR TITLE
fix(backend): update swagger documentation for routes get by id and post endpoints ss-277

### DIFF
--- a/apps/backend/src/modules/routes/routes.controller.ts
+++ b/apps/backend/src/modules/routes/routes.controller.ts
@@ -285,11 +285,15 @@ class RoutesController extends BaseController {
 	 *           type: string
 	 *     responses:
 	 *       200:
-	 *         description: Route was found succesfully
+	 *         description: Route was found successfully
 	 *         content:
 	 *           application/json:
 	 *             schema:
-	 *               $ref: '#/components/schemas/Route'
+	 *               type: object
+	 *               properties:
+	 *                 data:
+	 *                   type: object
+	 *                   $ref: '#/components/schemas/Route'
 	 */
 
 	public async find(

--- a/apps/backend/src/modules/routes/routes.controller.ts
+++ b/apps/backend/src/modules/routes/routes.controller.ts
@@ -199,12 +199,15 @@ class RoutesController extends BaseController {
 	 *             properties:
 	 *               name:
 	 *                 type: string
+	 *                 example: Landscape alley
 	 *               description:
 	 *                 type: string
+	 *                 example: An alley with blooming flowers
 	 *               pois:
 	 *                 type: array
 	 *                 items:
 	 *                   type: number
+	 *                 example: [1, 2]
 	 *     responses:
 	 *       200:
 	 *         description: The created route


### PR DESCRIPTION
Resolves #277 
Changes:
- add `data` object to the response example for `GET /routes/{id}` endpoint;
- update request example for `POST /routes` endpoint to include actual data.

<img width="929" height="829" alt="image" src="https://github.com/user-attachments/assets/aab77cc7-8afd-4eaa-a343-2caf33ff6e49" />

<img width="927" height="435" alt="image" src="https://github.com/user-attachments/assets/351edfb9-60dc-46f1-875a-e22673606eef" />
