### PR TITLE
fix(backend): ignore query in check-is-white-route ss-337

### DIFF
--- a/apps/backend/src/libs/modules/plugins/auth/libs/helpers/check-is-white-route.helper.ts
+++ b/apps/backend/src/libs/modules/plugins/auth/libs/helpers/check-is-white-route.helper.ts
@@ -22,12 +22,14 @@ const checkIsWhiteRoute = ({
 		return true;
 	}
 
+	const [urlWithoutQuery] = url.split("?");
+
 	return whiteRoutes.some(({ method: _method, path }) => {
 		if (_method !== method) {
 			return false;
 		}
 
-		return checkMatchUrlPattern(path, url);
+		return checkMatchUrlPattern(path, urlWithoutQuery as string);
 	});
 };
 


### PR DESCRIPTION
Changed:
Ignore url query, while checking for a white route
