### PR TITLE
refactor(frontend): remove placeholder property from password input ss-379

### DIFF
--- a/apps/frontend/src/libs/components/password-input/password-input.tsx
+++ b/apps/frontend/src/libs/components/password-input/password-input.tsx
@@ -16,7 +16,6 @@ type Properties<T extends FieldValues> = {
 	errors: FieldErrors<T>;
 	label: string;
 	name: FieldPath<T>;
-	placeholder?: string;
 };
 
 const PasswordInput = <T extends FieldValues>(
@@ -37,7 +36,6 @@ const PasswordInput = <T extends FieldValues>(
 				name: iconName,
 				onClick: handleIconClick,
 			}}
-			placeholder="Password"
 			type={type}
 			{...properties}
 		/>


### PR DESCRIPTION
Removed placeholder from password input component
<img width="581" height="297" alt="image" src="https://github.com/user-attachments/assets/61bea5a1-51a2-4481-b52a-cdf9c4503aff" />

<img width="670" height="417" alt="image" src="https://github.com/user-attachments/assets/079f24d7-7211-4e56-84c1-4647358e5337" />

Closes #379 