### PR TITLE
feat(frontend): implement explore routes block ss-270

### DIFF
--- a/apps/frontend/src/libs/components/explore-routes-block/constants/constants.ts
+++ b/apps/frontend/src/libs/components/explore-routes-block/constants/constants.ts
@@ -1,0 +1,2 @@
+export { DEGREE_TO_RAD } from "./degree-to-rad.constant.js";
+export { EARTH_RADIUS_KM } from "./earth-radius-km.constant.js";

--- a/apps/frontend/src/libs/components/explore-routes-block/constants/degree-to-rad.constant.ts
+++ b/apps/frontend/src/libs/components/explore-routes-block/constants/degree-to-rad.constant.ts
@@ -1,0 +1,5 @@
+import { PLANE_ANGEL } from "./plane-angel.constant.js";
+
+const DEGREE_TO_RAD = Math.PI / PLANE_ANGEL;
+
+export { DEGREE_TO_RAD };

--- a/apps/frontend/src/libs/components/explore-routes-block/constants/earth-radius-km.constant.ts
+++ b/apps/frontend/src/libs/components/explore-routes-block/constants/earth-radius-km.constant.ts
@@ -1,0 +1,3 @@
+const EARTH_RADIUS_KM = 6371;
+
+export { EARTH_RADIUS_KM };

--- a/apps/frontend/src/libs/components/explore-routes-block/constants/plane-angel.constant.ts
+++ b/apps/frontend/src/libs/components/explore-routes-block/constants/plane-angel.constant.ts
@@ -1,0 +1,3 @@
+const PLANE_ANGEL = 180;
+
+export { PLANE_ANGEL };

--- a/apps/frontend/src/libs/components/explore-routes-block/explore-routes-block.tsx
+++ b/apps/frontend/src/libs/components/explore-routes-block/explore-routes-block.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+
+import { useAppDispatch, useEffect, useState } from "~/libs/hooks/hooks.js";
+import { type RouteGetByIdResponseDto } from "~/modules/routes/libs/types/types.js";
+
+import { Loader, RouteCard } from "../components.js";
+import { getCurrentUserPosition, getSortedRoutes } from "./helpers/helpers.js";
+import styles from "./styles.module.css";
+
+const ExploreRoutesBlock = (): React.JSX.Element => {
+	const dispatch = useAppDispatch();
+	const [routes, setRoutes] = useState<RouteGetByIdResponseDto[]>([]);
+	const [loading, setLoading] = useState<boolean>(true);
+	const [error, setError] = useState<null | string>(null);
+
+	useEffect(() => {
+		const fetchData = async (): Promise<void> => {
+			try {
+				const userCoordinates = await getCurrentUserPosition();
+				const sortedRoutes = await getSortedRoutes(dispatch, userCoordinates);
+				setRoutes(sortedRoutes);
+			} catch (error: unknown) {
+				if (error instanceof Error) {
+					setError(error.message);
+				} else {
+					setError("An unknown error occured.");
+				}
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		void fetchData();
+	}, [dispatch]);
+
+	let content;
+
+	if (loading) {
+		content = (
+			<div className={styles["loading"]}>
+				<Loader />
+			</div>
+		);
+	} else if (error) {
+		content = <div className={styles["error"]}>Error: {error}</div>;
+	} else {
+		content =
+			routes.length === 0 ? (
+				<div className={styles["not-found"]}>No routes found nearby.</div>
+			) : (
+				<ul className={styles["list"]}>
+					{routes.map((route) => (
+						<RouteCard imageUrl={null} key={route.id} name={route.name} />
+					))}
+				</ul>
+			);
+	}
+
+	return (
+		<div className={styles["container"]}>
+			<h3 className={styles["title"]}>Explore routes</h3>
+			{content}
+		</div>
+	);
+};
+
+export { ExploreRoutesBlock };

--- a/apps/frontend/src/libs/components/explore-routes-block/helpers/get-current-user-position.helper.ts
+++ b/apps/frontend/src/libs/components/explore-routes-block/helpers/get-current-user-position.helper.ts
@@ -1,0 +1,15 @@
+const getCurrentUserPosition = (): Promise<[number, number]> => {
+	return new Promise((resolve, reject) => {
+		// eslint-disable-next-line sonarjs/no-intrusive-permissions
+		navigator.geolocation.getCurrentPosition(
+			(position) => {
+				resolve([position.coords.latitude, position.coords.longitude]);
+			},
+			(error) => {
+				reject(new Error(`Failed to get position: ${error.message}`));
+			},
+		);
+	});
+};
+
+export { getCurrentUserPosition };

--- a/apps/frontend/src/libs/components/explore-routes-block/helpers/get-distance.helper.ts
+++ b/apps/frontend/src/libs/components/explore-routes-block/helpers/get-distance.helper.ts
@@ -1,0 +1,27 @@
+import { DEGREE_TO_RAD, EARTH_RADIUS_KM } from "../constants/constants.js";
+
+const HALF = 0.5;
+const ONE = 1;
+const TWO = 2;
+
+function getDistance(
+	pointA: [number, number],
+	pointB: [number, number],
+): number {
+	const [lat1, lon1] = pointA;
+	const [lat2, lon2] = pointB;
+
+	const dLat = (lat2 - lat1) * DEGREE_TO_RAD;
+	const dLon = (lon2 - lon1) * DEGREE_TO_RAD;
+
+	const a =
+		Math.sin(dLat * HALF) ** TWO +
+		Math.cos(lat1 * DEGREE_TO_RAD) *
+			Math.cos(lat2 * DEGREE_TO_RAD) *
+			Math.sin(dLon * HALF) ** TWO;
+	const c = TWO * Math.atan2(Math.sqrt(a), Math.sqrt(ONE - a));
+
+	return EARTH_RADIUS_KM * c;
+}
+
+export { getDistance };

--- a/apps/frontend/src/libs/components/explore-routes-block/helpers/get-poi-coordinates.helper.ts
+++ b/apps/frontend/src/libs/components/explore-routes-block/helpers/get-poi-coordinates.helper.ts
@@ -1,0 +1,17 @@
+import { unwrapResult } from "@reduxjs/toolkit";
+
+import { type useAppDispatch } from "~/libs/hooks/hooks.js";
+import { actions as pointsOfInterestActions } from "~/modules/points-of-interest/points-of-interest.js";
+
+const getPOICoordinates = async (
+	dispatch: ReturnType<typeof useAppDispatch>,
+	id: number,
+): Promise<[number, number]> => {
+	const action = await dispatch(pointsOfInterestActions.getById(id));
+
+	const result = unwrapResult(action);
+
+	return result.data.location.coordinates;
+};
+
+export { getPOICoordinates };

--- a/apps/frontend/src/libs/components/explore-routes-block/helpers/get-routes.helper.ts
+++ b/apps/frontend/src/libs/components/explore-routes-block/helpers/get-routes.helper.ts
@@ -1,0 +1,17 @@
+import { unwrapResult } from "@reduxjs/toolkit";
+
+import { type useAppDispatch } from "~/libs/hooks/hooks.js";
+import { type RouteGetByIdResponseDto } from "~/modules/routes/libs/types/types.js";
+import { actions as routesActions } from "~/modules/routes/routes.js";
+
+const getRoutes = async (
+	dispatch: ReturnType<typeof useAppDispatch>,
+): Promise<RouteGetByIdResponseDto[]> => {
+	const action = await dispatch(routesActions.getAll());
+
+	const result = unwrapResult(action);
+
+	return result.data;
+};
+
+export { getRoutes };

--- a/apps/frontend/src/libs/components/explore-routes-block/helpers/get-sorted-routes.helper.ts
+++ b/apps/frontend/src/libs/components/explore-routes-block/helpers/get-sorted-routes.helper.ts
@@ -1,0 +1,34 @@
+import { type useAppDispatch } from "~/libs/hooks/hooks.js";
+import { type RouteGetByIdResponseDto } from "~/modules/routes/libs/types/types.js";
+
+import { getDistance, getPOICoordinates, getRoutes } from "./helpers.js";
+
+const getSortedRoutes = async (
+	dispatch: ReturnType<typeof useAppDispatch>,
+	userCoordinates: [number, number],
+): Promise<RouteGetByIdResponseDto[]> => {
+	const allRoutes = await getRoutes(dispatch);
+	const routesWithDistances = await Promise.all(
+		allRoutes.map(async (route) => {
+			const startingPoi = route.pois.find((poi) => poi.visitOrder === 0);
+
+			if (!startingPoi) {
+				return { ...route, distanceToUser: Infinity };
+			}
+
+			const pointCoordinates = await getPOICoordinates(
+				dispatch,
+				startingPoi.id,
+			);
+			const distance = getDistance(userCoordinates, pointCoordinates);
+
+			return { ...route, distanceToUser: distance };
+		}),
+	);
+
+	return routesWithDistances.sort(
+		(a, b) => a.distanceToUser - b.distanceToUser,
+	);
+};
+
+export { getSortedRoutes };

--- a/apps/frontend/src/libs/components/explore-routes-block/helpers/helpers.ts
+++ b/apps/frontend/src/libs/components/explore-routes-block/helpers/helpers.ts
@@ -1,0 +1,5 @@
+export { getCurrentUserPosition } from "./get-current-user-position.helper.js";
+export { getDistance } from "./get-distance.helper.js";
+export { getPOICoordinates } from "./get-poi-coordinates.helper.js";
+export { getRoutes } from "./get-routes.helper.js";
+export { getSortedRoutes } from "./get-sorted-routes.helper.js";

--- a/apps/frontend/src/libs/components/explore-routes-block/styles.module.css
+++ b/apps/frontend/src/libs/components/explore-routes-block/styles.module.css
@@ -1,0 +1,34 @@
+.container {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+	width: 464px;
+	max-height: calc(100vh - 110px);
+	padding: 24px 32px;
+	background-color: var(--color-base);
+	border: 1px solid var(--color-stroke-weak);
+	border-radius: 16px;
+}
+
+.title {
+	margin: 0;
+	font-family: var(--font-family);
+	font-size: var(--font-size-h3);
+	font-weight: var(--font-weight-semibold);
+	color: hsl(0deg 0% 0% / 100%);
+}
+
+.list {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+	padding: 0;
+	margin: 0;
+	overflow-y: scroll;
+	scrollbar-width: none;
+	scroll-behavior: smooth;
+}
+
+.error {
+	color: var(--color-text-error);
+}

--- a/apps/frontend/src/modules/points-of-interest/points-of-interest-api.ts
+++ b/apps/frontend/src/modules/points-of-interest/points-of-interest-api.ts
@@ -36,6 +36,21 @@ class PointOfInterestApi extends BaseHTTPApi {
 
 		return (await response.json()) as APIResponse<PointsOfInterestResponseDto>;
 	}
+
+	public async getById(
+		id: number,
+	): Promise<APIResponse<PointsOfInterestResponseDto>> {
+		const response = await this.load<APIResponse<PointsOfInterestResponseDto>>(
+			this.getFullEndpoint(PointsOfInterestApiPath.ROOT, String(id), {}),
+			{
+				contentType: ContentType.JSON,
+				hasAuth: true,
+				method: "GET",
+			},
+		);
+
+		return await response.json();
+	}
 }
 
 export { PointOfInterestApi };

--- a/apps/frontend/src/modules/points-of-interest/slices/actions.ts
+++ b/apps/frontend/src/modules/points-of-interest/slices/actions.ts
@@ -21,4 +21,14 @@ const create = createAsyncThunk<
 	return pointOfInterest;
 });
 
-export { create };
+const getById = createAsyncThunk<
+	APIResponse<PointsOfInterestResponseDto>,
+	number,
+	AsyncThunkConfig
+>(`${sliceName}/find-by-id`, async (id, { extra }) => {
+	const { pointOfInterestApi } = extra;
+
+	return await pointOfInterestApi.getById(id);
+});
+
+export { create, getById };

--- a/apps/frontend/src/modules/points-of-interest/slices/points-of-interest.slice.ts
+++ b/apps/frontend/src/modules/points-of-interest/slices/points-of-interest.slice.ts
@@ -4,7 +4,7 @@ import { DataStatus } from "~/libs/enums/enums.js";
 import { type ValueOf } from "~/libs/types/types.js";
 import { type PointsOfInterestResponseDto } from "~/modules/points-of-interest/points-of-interest.js";
 
-import { create } from "./actions.js";
+import { create, getById } from "./actions.js";
 
 type State = {
 	createStatus: ValueOf<typeof DataStatus>;
@@ -29,6 +29,17 @@ const { actions, name, reducer } = createSlice({
 		});
 		builder.addCase(create.rejected, (state) => {
 			state.createStatus = DataStatus.REJECTED;
+		});
+
+		builder.addCase(getById.pending, (state) => {
+			state.dataStatus = DataStatus.PENDING;
+		});
+		builder.addCase(getById.fulfilled, (state, { payload }) => {
+			state.data = payload.data;
+			state.dataStatus = DataStatus.FULFILLED;
+		});
+		builder.addCase(getById.rejected, (state) => {
+			state.dataStatus = DataStatus.REJECTED;
 		});
 	},
 	initialState,

--- a/apps/frontend/src/modules/points-of-interest/slices/points-of-interest.ts
+++ b/apps/frontend/src/modules/points-of-interest/slices/points-of-interest.ts
@@ -1,9 +1,10 @@
-import { create } from "./actions.js";
+import { create, getById } from "./actions.js";
 import { actions } from "./points-of-interest.slice.js";
 
 const allActions = {
 	...actions,
 	create,
+	getById,
 };
 
 export { allActions as actions };

--- a/apps/frontend/src/modules/routes/libs/types/types.ts
+++ b/apps/frontend/src/modules/routes/libs/types/types.ts
@@ -1,1 +1,4 @@
-export { type RouteGetByIdResponseDto } from "@smartscapes/shared";
+export {
+	type RouteFindAllOptions,
+	type RouteGetByIdResponseDto,
+} from "@smartscapes/shared";

--- a/apps/frontend/src/modules/routes/routes-api.ts
+++ b/apps/frontend/src/modules/routes/routes-api.ts
@@ -1,4 +1,8 @@
-import { type RouteGetByIdResponseDto } from "@smartscapes/shared";
+import {
+	ContentType,
+	type RouteFindAllOptions,
+	type RouteGetByIdResponseDto,
+} from "@smartscapes/shared";
 
 import { APIPath } from "~/libs/enums/enums.js";
 import { BaseHTTPApi } from "~/libs/modules/api/api.js";
@@ -17,6 +21,27 @@ type Constructor = {
 class RoutesApi extends BaseHTTPApi {
 	public constructor({ baseUrl, http, storage }: Constructor) {
 		super({ baseUrl, http, path: APIPath.ROUTES, storage });
+	}
+
+	public async getAll(
+		query?: RouteFindAllOptions,
+	): Promise<APIResponse<RouteGetByIdResponseDto[]>> {
+		const queryParameters: Record<string, string> = {};
+
+		if (query?.name) {
+			queryParameters["name"] = query.name;
+		}
+
+		const response = await this.load<APIResponse<RouteGetByIdResponseDto[]>>(
+			this.getFullEndpoint(RoutesApiPath.ROOT, queryParameters),
+			{
+				contentType: ContentType.JSON,
+				hasAuth: false,
+				method: "GET",
+			},
+		);
+
+		return await response.json();
 	}
 
 	public async getRouteById(

--- a/apps/frontend/src/modules/routes/slices/actions.ts
+++ b/apps/frontend/src/modules/routes/slices/actions.ts
@@ -2,7 +2,10 @@ import { createAsyncThunk } from "@reduxjs/toolkit";
 
 import { type APIResponse, type AsyncThunkConfig } from "~/libs/types/types.js";
 
-import { type RouteGetByIdResponseDto } from "../libs/types/types.js";
+import {
+	type RouteFindAllOptions,
+	type RouteGetByIdResponseDto,
+} from "../libs/types/types.js";
 import { name as sliceName } from "./route.slice.js";
 
 const getRouteById = createAsyncThunk<
@@ -15,4 +18,14 @@ const getRouteById = createAsyncThunk<
 	return routeApi.getRouteById(id);
 });
 
-export { getRouteById };
+const getAll = createAsyncThunk<
+	APIResponse<RouteGetByIdResponseDto[]>,
+	RouteFindAllOptions | undefined,
+	AsyncThunkConfig
+>(`${sliceName}/get-all`, async (options, { extra }) => {
+	const { routeApi } = extra;
+
+	return await routeApi.getAll(options);
+});
+
+export { getAll, getRouteById };

--- a/apps/frontend/src/modules/routes/slices/route.slice.ts
+++ b/apps/frontend/src/modules/routes/slices/route.slice.ts
@@ -4,16 +4,18 @@ import { DataStatus } from "~/libs/enums/enums.js";
 import { type ValueOf } from "~/libs/types/types.js";
 
 import { type RouteGetByIdResponseDto } from "../libs/types/types.js";
-import { getRouteById } from "./actions.js";
+import { getAll, getRouteById } from "./actions.js";
 
 type State = {
 	dataStatus: ValueOf<typeof DataStatus>;
 	route: null | RouteGetByIdResponseDto;
+	routes: RouteGetByIdResponseDto[];
 };
 
 const initialState: State = {
 	dataStatus: DataStatus.IDLE,
 	route: null,
+	routes: [],
 };
 
 const { actions, name, reducer } = createSlice({
@@ -26,6 +28,17 @@ const { actions, name, reducer } = createSlice({
 			state.dataStatus = DataStatus.FULFILLED;
 		});
 		builder.addCase(getRouteById.rejected, (state) => {
+			state.dataStatus = DataStatus.REJECTED;
+		});
+
+		builder.addCase(getAll.pending, (state) => {
+			state.dataStatus = DataStatus.PENDING;
+		});
+		builder.addCase(getAll.fulfilled, (state, action) => {
+			state.routes = action.payload.data;
+			state.dataStatus = DataStatus.FULFILLED;
+		});
+		builder.addCase(getAll.rejected, (state) => {
 			state.dataStatus = DataStatus.REJECTED;
 		});
 	},

--- a/apps/frontend/src/modules/routes/slices/routes.ts
+++ b/apps/frontend/src/modules/routes/slices/routes.ts
@@ -1,8 +1,9 @@
-import { getRouteById } from "./actions.js";
+import { getAll, getRouteById } from "./actions.js";
 import { actions } from "./route.slice.js";
 
 const allActions = {
 	...actions,
+	getAll,
 	getRouteById,
 };
 

--- a/apps/frontend/src/pages/explore/explore.tsx
+++ b/apps/frontend/src/pages/explore/explore.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { MapProvider } from "~/libs/components/components.js";
+import { ExploreRoutesBlock } from "~/libs/components/explore-routes-block/explore-routes-block.js";
 import { useMapClient } from "~/libs/hooks/hooks.js";
 
 import { mockPOIs } from "./mock-pois.js";
@@ -18,6 +19,9 @@ const DummyMapClientUser = (): null => {
 const Explore = (): React.JSX.Element => {
 	return (
 		<main className={styles["main"]}>
+			<div className={styles["routes-container"]}>
+				<ExploreRoutesBlock />
+			</div>
 			<div className={styles["container"]}>
 				<MapProvider markers={mockPOIs}>
 					<DummyMapClientUser />

--- a/apps/frontend/src/pages/explore/styles.module.css
+++ b/apps/frontend/src/pages/explore/styles.module.css
@@ -3,6 +3,13 @@
 	flex-grow: 1;
 }
 
+.routes-container {
+	position: absolute;
+	top: 32px;
+	left: 32px;
+	z-index: 1;
+}
+
 .container {
 	flex-grow: 1;
 }


### PR DESCRIPTION
Implement explore routes block, namely implement actions, api, thunk for getById in poi and getAll in routes. Create a component explore routes block that create infinite scroll sidebar with routes sorted by the closest starting point to user. 