### PR TITLE
feat(frontend): add separate data status for route-details patch ss-517

### DIFF
--- a/apps/frontend/src/modules/routes/slices/route-details.slice.ts
+++ b/apps/frontend/src/modules/routes/slices/route-details.slice.ts
@@ -8,11 +8,13 @@ import { getById, patch } from "./actions.js";
 
 type State = {
 	dataStatus: ValueOf<typeof DataStatus>;
+	patchStatus: ValueOf<typeof DataStatus>;
 	route: null | RouteGetByIdResponseDto;
 };
 
 const initialState: State = {
 	dataStatus: DataStatus.IDLE,
+	patchStatus: DataStatus.IDLE,
 	route: null,
 };
 
@@ -30,14 +32,14 @@ const { actions, name, reducer } = createSlice({
 		});
 
 		builder.addCase(patch.pending, (state) => {
-			state.dataStatus = DataStatus.PENDING;
+			state.patchStatus = DataStatus.PENDING;
 		});
 		builder.addCase(patch.fulfilled, (state, action) => {
 			state.route = action.payload.data;
-			state.dataStatus = DataStatus.FULFILLED;
+			state.patchStatus = DataStatus.FULFILLED;
 		});
 		builder.addCase(patch.rejected, (state) => {
-			state.dataStatus = DataStatus.REJECTED;
+			state.patchStatus = DataStatus.REJECTED;
 		});
 	},
 	initialState,


### PR DESCRIPTION
Added separate data status for patch


https://github.com/user-attachments/assets/84395448-2a3b-48cb-8513-c571f65a6e7f



Closes #517 