### PR TITLE
refactor(frontend): update route details page with cancel handler, refactor poi details page ss-514

### DIFF
--- a/apps/frontend/src/pages/points-of-interest-details/points-of-interest-details.tsx
+++ b/apps/frontend/src/pages/points-of-interest-details/points-of-interest-details.tsx
@@ -61,7 +61,7 @@ const PointsOfInterestDetails = (): React.JSX.Element => {
 		setIsEditMode((previous) => !previous);
 	}, []);
 
-	const handleCancel = useCallback(() => {
+	const handleResetFormValues = useCallback(() => {
 		if (!pointOfInterest) {
 			return;
 		}
@@ -70,8 +70,11 @@ const PointsOfInterestDetails = (): React.JSX.Element => {
 			description: pointOfInterest.description ?? "",
 			name: pointOfInterest.name,
 		});
-		setIsEditMode(false);
 	}, [handleReset, pointOfInterest]);
+	const handleCancel = useCallback(() => {
+		handleResetFormValues();
+		setIsEditMode(false);
+	}, [handleResetFormValues]);
 
 	const handlePatchRequest = useCallback(() => {
 		if (pointOfInterest) {
@@ -91,15 +94,8 @@ const PointsOfInterestDetails = (): React.JSX.Element => {
 	}, [dispatch, poiId]);
 
 	useEffect(() => {
-		if (!pointOfInterest) {
-			return;
-		}
-
-		handleReset({
-			description: pointOfInterest.description ?? "",
-			name: pointOfInterest.name,
-		});
-	}, [pointOfInterest, handleReset]);
+		handleResetFormValues();
+	}, [handleResetFormValues]);
 
 	if (dataStatus === DataStatus.REJECTED) {
 		return <NotFound />;

--- a/apps/frontend/src/pages/route-details/route-details.tsx
+++ b/apps/frontend/src/pages/route-details/route-details.tsx
@@ -37,7 +37,7 @@ const RouteDetails = (): React.JSX.Element => {
 		({ routeDetails }) => routeDetails.dataStatus,
 	);
 
-	const { control, errors, getValues, handleValueSet } =
+	const { control, errors, getValues, handleReset } =
 		useAppForm<RoutePatchRequestDto>({
 			defaultValues: ROUTE_FORM_DEFAULT_VALUES,
 		});
@@ -52,6 +52,22 @@ const RouteDetails = (): React.JSX.Element => {
 	const handleToggleEditMode = useCallback(() => {
 		setIsEditMode((isEditMode) => !isEditMode);
 	}, []);
+
+	const handleResetFormValues = useCallback(() => {
+		if (!route) {
+			return;
+		}
+
+		handleReset({
+			description: route.description,
+			name: route.name,
+		});
+	}, [handleReset, route]);
+
+	const handleCancel = useCallback(() => {
+		handleResetFormValues();
+		setIsEditMode(false);
+	}, [handleResetFormValues]);
 
 	const handlePatchRequest = useCallback(() => {
 		if (route) {
@@ -71,11 +87,8 @@ const RouteDetails = (): React.JSX.Element => {
 	}, [dispatch, routeId]);
 
 	useEffect(() => {
-		if (route) {
-			handleValueSet("name", route.name);
-			handleValueSet("description", route.description);
-		}
-	}, [route, handleValueSet]);
+		handleResetFormValues();
+	}, [handleResetFormValues]);
 
 	if (dataStatus === DataStatus.PENDING || dataStatus === DataStatus.IDLE) {
 		return <Loader />;
@@ -106,7 +119,7 @@ const RouteDetails = (): React.JSX.Element => {
 							/>
 							<div className={styles["edit-mode-controls"]}>
 								<Button label="Save" onClick={handlePatchRequest} />
-								<Button label="Cancel" onClick={handleToggleEditMode} />
+								<Button label="Cancel" onClick={handleCancel} />
 							</div>
 						</>
 					) : (


### PR DESCRIPTION
Added handleCancel, which resets everything to the last saved changes when the cancel button is pressed in edit mode
Updated point of interest details page by adding handler to reset form values to avoid duplicating code



https://github.com/user-attachments/assets/f4511c09-d5d7-43c0-8349-8848955355cf



Closes #514 