### PR TITLE
fix(frontend): add styles to prevent long review overflowing ss-540

### DIFF
--- a/apps/frontend/src/libs/components/review-card/styles.module.css
+++ b/apps/frontend/src/libs/components/review-card/styles.module.css
@@ -1,5 +1,6 @@
 .card {
 	gap: 24px;
+	min-width: 0;
 	background: var(--color-base);
 }
 
@@ -18,7 +19,10 @@
 
 .content {
 	gap: 24px;
+	max-width: 750px;
 	font-size: var(--font-size-small);
 	line-height: 1.5;
 	color: var(--color-text-strong);
+	overflow-wrap: break-word;
+	white-space: pre-wrap;
 }


### PR DESCRIPTION
fixed long review overflowing
<img width="1315" height="872" alt="image" src="https://github.com/user-attachments/assets/cb4cbb43-6d67-461c-a752-e37b96eb3c5c" />

Closes #540 
