### PR TITLE
feat(frontend): integrate route creation with construct route flow ss-542

### DIFF
--- a/apps/frontend/src/libs/components/button/button.tsx
+++ b/apps/frontend/src/libs/components/button/button.tsx
@@ -3,6 +3,7 @@ import { combineClassNames } from "~/libs/helpers/helpers.js";
 import styles from "./styles.module.css";
 
 type Properties = {
+	isDisabled?: boolean;
 	label: string;
 	onClick?: () => void;
 	to?: string;
@@ -11,6 +12,7 @@ type Properties = {
 };
 
 const Button = ({
+	isDisabled = false,
 	label,
 	onClick,
 	to,
@@ -34,7 +36,12 @@ const Button = ({
 	}
 
 	return (
-		<button className={buttonClass} onClick={onClick} type={type}>
+		<button
+			className={buttonClass}
+			disabled={isDisabled}
+			onClick={onClick}
+			type={type}
+		>
 			{label}
 		</button>
 	);

--- a/apps/frontend/src/modules/routes/libs/enums/route-notification.enum.ts
+++ b/apps/frontend/src/modules/routes/libs/enums/route-notification.enum.ts
@@ -1,4 +1,5 @@
 const RouteNotification = {
+	CREATED: "The route has been successfully created",
 	UPDATED: "The route has been successfully updated",
 } as const;
 

--- a/apps/frontend/src/modules/routes/slices/actions.ts
+++ b/apps/frontend/src/modules/routes/slices/actions.ts
@@ -36,8 +36,10 @@ const create = createAsyncThunk<
 	AsyncThunkConfig
 >(`${routesSliceName}/create`, async (payload, { extra }) => {
 	const { routesApi } = extra;
+	const route = await routesApi.create(payload);
+	toastNotifier.showSuccess(RouteNotification.CREATED);
 
-	return await routesApi.create(payload);
+	return route;
 });
 
 const getById = createAsyncThunk<

--- a/apps/frontend/src/modules/routes/slices/routes.slice.ts
+++ b/apps/frontend/src/modules/routes/slices/routes.slice.ts
@@ -70,7 +70,11 @@ const { actions, name, reducer } = createSlice({
 	},
 	initialState,
 	name: "routes",
-	reducers: {},
+	reducers: {
+		resetCreateStatus(state) {
+			state.createStatus = DataStatus.IDLE;
+		},
+	},
 });
 
 export { actions, name, reducer };

--- a/apps/frontend/src/pages/construct-route/construct-route.tsx
+++ b/apps/frontend/src/pages/construct-route/construct-route.tsx
@@ -47,14 +47,18 @@ const ConstructRoute = (): React.JSX.Element => {
 		return { geometry: routeLineString.geometry, id: "planned" };
 	}, [routeLineString]);
 
+	const plannedRouteId = routeLineString?.id ?? null;
+
 	return (
 		<main className={styles["main"]}>
 			<div className={styles["map"]}>
 				<MapProvider markers={markers} routeLine={routeLine} />
 			</div>
 			<SidePanel
+				isSaveDisabled={!routeLineString}
 				onRemovePoi={handleRemovePoi}
 				onSelectPoi={handleSelectPoi}
+				plannedRouteId={plannedRouteId}
 				pointsOfInterest={selectedPois}
 			/>
 		</main>

--- a/apps/frontend/src/pages/construct-route/libs/components/point-of-interest-card/point-of-interest-card.tsx
+++ b/apps/frontend/src/pages/construct-route/libs/components/point-of-interest-card/point-of-interest-card.tsx
@@ -30,7 +30,7 @@ const PointOfInterestCard = ({
 			<span className={styles["name"]}>{name}</span>
 
 			<div className={styles["right"]}>
-				<Link to={poiDetailsPath}>
+				<Link target="_blank" to={poiDetailsPath}>
 					<div className={styles["icon"]}>
 						<Icon height={24} name="link" width={24} />
 					</div>

--- a/apps/frontend/src/pages/construct-route/libs/components/side-panel/side-panel.tsx
+++ b/apps/frontend/src/pages/construct-route/libs/components/side-panel/side-panel.tsx
@@ -101,10 +101,10 @@ const SidePanel = ({
 		);
 
 		const [path, query = ""] = route.split("?");
-		const searchParameters_ = new URLSearchParams(query);
-		searchParameters_.set("plannedRouteId", String(plannedRouteId));
+		const newSearchParameters = new URLSearchParams(query);
+		newSearchParameters.set("plannedRouteId", String(plannedRouteId));
 
-		navigate(`${String(path)}?${searchParameters_.toString()}`);
+		navigate(`${String(path)}?${newSearchParameters.toString()}`);
 	}, [dispatch, plannedRouteId, pointsOfInterest, searchParameters, navigate]);
 
 	const poiSelectOptions = useMemo(() => {

--- a/apps/frontend/src/pages/construct-route/libs/components/side-panel/side-panel.tsx
+++ b/apps/frontend/src/pages/construct-route/libs/components/side-panel/side-panel.tsx
@@ -16,6 +16,7 @@ import {
 import { type SelectOption } from "~/libs/types/types.js";
 import { type PointsOfInterestGetAllItemResponseDto } from "~/modules/points-of-interest/points-of-interest.js";
 import { actions as routeActions } from "~/modules/routes/routes.js";
+import { preserveCreateRouteFormData } from "~/modules/routes/slices/actions.js";
 
 import { PointOfInterestCard } from "../point-of-interest-card/point-of-interest-card.js";
 import styles from "./styles.module.css";
@@ -93,13 +94,18 @@ const SidePanel = ({
 			return;
 		}
 
+		const poiIds = pointsOfInterest.map(({ id }) => id);
+
+		void dispatch(
+			preserveCreateRouteFormData({ plannedPathId: plannedRouteId, poiIds }),
+		);
+
 		const [path, query = ""] = route.split("?");
 		const searchParameters_ = new URLSearchParams(query);
-
 		searchParameters_.set("plannedRouteId", String(plannedRouteId));
 
 		navigate(`${String(path)}?${searchParameters_.toString()}`);
-	}, [plannedRouteId, searchParameters, navigate]);
+	}, [dispatch, plannedRouteId, pointsOfInterest, searchParameters, navigate]);
 
 	const poiSelectOptions = useMemo(() => {
 		return filteredPois.map((poi) => ({

--- a/apps/frontend/src/pages/construct-route/libs/components/side-panel/side-panel.tsx
+++ b/apps/frontend/src/pages/construct-route/libs/components/side-panel/side-panel.tsx
@@ -87,19 +87,20 @@ const SidePanel = ({
 	}, [dispatch, pointsOfInterest]);
 
 	const handleSaveClick = useCallback(() => {
-		const rt = searchParameters.get("returnTo");
+		const route = searchParameters.get("returnTo");
 
-		if (!rt || !plannedRouteId) {
+		if (!route || !plannedRouteId) {
 			return;
 		}
 
-		const [path, qs = ""] = rt.split("?");
-		const sp = new URLSearchParams(qs);
+		const [path, query = ""] = route.split("?");
+		const searchParameters_ = new URLSearchParams(query);
 
-		sp.set("plannedRouteId", String(plannedRouteId));
+		searchParameters_.set("plannedRouteId", String(plannedRouteId));
 
-		navigate(`${String(path)}?${sp.toString()}`);
+		navigate(`${String(path)}?${searchParameters_.toString()}`);
 	}, [plannedRouteId, searchParameters, navigate]);
+
 	const poiSelectOptions = useMemo(() => {
 		return filteredPois.map((poi) => ({
 			label: poi.name,

--- a/apps/frontend/src/pages/construct-route/libs/components/side-panel/styles.module.css
+++ b/apps/frontend/src/pages/construct-route/libs/components/side-panel/styles.module.css
@@ -54,3 +54,10 @@
 	margin: 0;
 	overflow-y: auto;
 }
+
+.footer {
+	display: flex;
+	gap: 96px;
+	align-items: center;
+	justify-content: space-between;
+}

--- a/apps/frontend/src/pages/construct-route/libs/components/side-panel/styles.module.css
+++ b/apps/frontend/src/pages/construct-route/libs/components/side-panel/styles.module.css
@@ -34,6 +34,7 @@
 
 .body {
 	display: flex;
+	flex: 1;
 	flex-direction: column;
 	gap: 16px;
 	overflow: hidden;
@@ -55,5 +56,6 @@
 }
 
 .footer {
+	align-self: flex-end;
 	margin-left: auto;
 }

--- a/apps/frontend/src/pages/construct-route/libs/components/side-panel/styles.module.css
+++ b/apps/frontend/src/pages/construct-route/libs/components/side-panel/styles.module.css
@@ -1,11 +1,10 @@
 .container {
 	position: absolute;
 	inset: 0;
-	z-index: 3;
+	z-index: 2;
 	width: max-content;
 	height: 100%;
 	padding: 32px;
-	padding-bottom: 64px;
 }
 
 .panel {

--- a/apps/frontend/src/pages/construct-route/libs/components/side-panel/styles.module.css
+++ b/apps/frontend/src/pages/construct-route/libs/components/side-panel/styles.module.css
@@ -55,8 +55,5 @@
 }
 
 .footer {
-	display: flex;
-	gap: 96px;
-	align-items: center;
-	justify-content: space-between;
+	margin-left: auto;
 }

--- a/apps/frontend/src/pages/manage-routes/manage-routes.tsx
+++ b/apps/frontend/src/pages/manage-routes/manage-routes.tsx
@@ -34,11 +34,17 @@ const ManageRoutes = (): React.JSX.Element => {
 		(state) => state.auth.authenticatedUser,
 	) as UserAuthResponseDto;
 
-	const { control, errors, getValues, handleReset, handleSubmit } =
-		useAppForm<RouteCreateRequestDto>({
-			defaultValues: DEFAULT_CREATE_ROUTE_PAYLOAD,
-			validationSchema: routesCreateValidationSchema,
-		});
+	const {
+		control,
+		errors,
+		getValues,
+		handleReset,
+		handleSubmit,
+		handleValueSet,
+	} = useAppForm<RouteCreateRequestDto>({
+		defaultValues: DEFAULT_CREATE_ROUTE_PAYLOAD,
+		validationSchema: routesCreateValidationSchema,
+	});
 
 	const plannedRouteId = searchParameters.get("plannedRouteId");
 
@@ -114,13 +120,18 @@ const ManageRoutes = (): React.JSX.Element => {
 				...createRouteFormData,
 			});
 		}
-	}, [createRouteFormData, handleReset]);
+
+		if (authenticatedUser.id) {
+			handleValueSet("createdByUserId", authenticatedUser.id);
+		}
+	}, [createRouteFormData, handleReset, authenticatedUser.id, handleValueSet]);
 
 	useEffect(() => {
 		if (createStatus === DataStatus.FULFILLED) {
 			clearModalAndReset();
+			dispatch(routesActions.resetCreateStatus());
 		}
-	}, [createStatus, clearModalAndReset]);
+	}, [dispatch, createStatus, clearModalAndReset]);
 
 	useEffect(() => {
 		const handleVisibilityChange = (): void => {


### PR DESCRIPTION
Updates:
- **Button component**
  - added support for the isDisabled property to allow disabling buttons when necessary

- **Construct Route page**
  - updated logic to pass isSaveDisabled and plannedRouteId props to the side panel to control the save functionality properly

- **POI Card**
  - modified the link action so that clicking on the POI link now opens it in a new browser tab instead of the same tab
- **Side Panel**
  - added **Save** button.  
  - updated the save handler to persist constructed route data before redirecting to the modal for route creation

Closes #542