### PR TITLE
fix(frontend): swap poi coordinates to correctly display location ss-571

### DIFF
--- a/apps/frontend/src/pages/points-of-interest-details/points-of-interest-details.tsx
+++ b/apps/frontend/src/pages/points-of-interest-details/points-of-interest-details.tsx
@@ -116,7 +116,7 @@ const PointsOfInterestDetails = (): React.JSX.Element => {
 	const { description, name } = pointOfInterest;
 	const hasDescription = Boolean(description);
 
-	const [latitude, longitude] = pointOfInterest.location.coordinates;
+	const [longitude, latitude] = pointOfInterest.location.coordinates;
 
 	return (
 		<main className={styles["container"]}>


### PR DESCRIPTION
Fixed coordinates order to properly display marker on poi details page

Closes #571


https://github.com/user-attachments/assets/78508ae2-d0cd-47d8-92c9-4abda0f7051d

 