### PR TITLE
fix(frontend): handle-value-set for poi after entering edit mode ss-550

### DIFF
--- a/apps/frontend/src/pages/points-of-interest-details/points-of-interest-details.tsx
+++ b/apps/frontend/src/pages/points-of-interest-details/points-of-interest-details.tsx
@@ -41,7 +41,7 @@ const PointsOfInterestDetails = (): React.JSX.Element => {
 		(state) => state.pointOfInterestDetails.pointOfInterest,
 	);
 
-	const { control, errors, getValues, handleReset } =
+	const { control, errors, getValues, handleReset, handleValueSet } =
 		useAppForm<PointOfInterestPatchRequestDto>({
 			defaultValues: POINT_OF_INTEREST_FORM_DEFAULT_VALUES,
 		});
@@ -60,6 +60,13 @@ const PointsOfInterestDetails = (): React.JSX.Element => {
 	const handleToggleEditMode = useCallback(() => {
 		setIsEditMode((previous) => !previous);
 	}, []);
+
+	useEffect(() => {
+		if (pointOfInterest && isEditMode) {
+			handleValueSet("name", pointOfInterest.name);
+			handleValueSet("description", pointOfInterest.description ?? "");
+		}
+	}, [pointOfInterest, handleValueSet, isEditMode]);
 
 	const handleResetFormValues = useCallback(() => {
 		if (!pointOfInterest) {


### PR DESCRIPTION
Added handleValueSet() for poi page, after entering edit mode. Same logic as a route page